### PR TITLE
add hex color alpha channel support

### DIFF
--- a/Syntaxes/Better Less.YAML-tmLanguage
+++ b/Syntaxes/Better Less.YAML-tmLanguage
@@ -388,7 +388,7 @@ repository:
     - name: support.constant.color.w3c-special-color-keyword.less
       match: \b((?i)currentColor|transparent)\b
     - name: constant.other.color.rgb-value.less
-      match: (#)(\h{3}|\h{6})\b
+      match: (#)(\h{3}|\h{4}|\h{6}|\h{8})\b
       captures:
         '1': {name: punctuation.definition.constant.less}
 

--- a/Syntaxes/Better Less.tmLanguage
+++ b/Syntaxes/Better Less.tmLanguage
@@ -1263,7 +1263,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(#)(\h{3}|\h{6})\b</string>
+					<string>(#)(\h{3}|\h{4}|\h{6}|\h{8})\b</string>
 					<key>name</key>
 					<string>constant.other.color.rgb-value.less</string>
 				</dict>

--- a/Tests/syntax_test_less.less
+++ b/Tests/syntax_test_less.less
@@ -949,3 +949,15 @@ a {
     --asdf: 23px;
     transform: translate(var(--asdf)) scale(var(--asdf)) skew(calc(var(--asdf)));
 }
+
+.colors {
+    color: #A1B;
+    color: #1A2B;
+    color: #1A2B3C;
+    color: #1A2B3C4D;
+
+    color: #BEE;
+    color: #ACDC;
+    color: #A1C0DE;
+    color: #ABBAFADE;
+}


### PR DESCRIPTION
Allows for 4- and 8-value hex colors.

Before:
![image](https://github.com/radium-v/Better-Less/assets/863023/c901f155-9acc-46f8-953b-c68cc0366baf)



After:
![image](https://github.com/radium-v/Better-Less/assets/863023/ab5957bd-689e-43a9-ace5-3ae4bdbffad8)


