### PR TITLE
add "or" to mixin guards

### DIFF
--- a/Syntaxes/Better Less.YAML-tmLanguage
+++ b/Syntaxes/Better Less.YAML-tmLanguage
@@ -1134,7 +1134,7 @@ repository:
 
   less-mixin-guards:
     patterns:
-    - begin: \s*(and|not)?\s*(?=\()
+    - begin: \s*(and|not|or)?\s*(?=\()
       beginCaptures:
         '1': {name: keyword.operator.logical.less}
       end: \)

--- a/Syntaxes/Better Less.tmLanguage
+++ b/Syntaxes/Better Less.tmLanguage
@@ -3709,7 +3709,7 @@
 			<array>
 				<dict>
 					<key>begin</key>
-					<string>\s*(and|not)?\s*(?=\()</string>
+					<string>\s*(and|not|or)?\s*(?=\()</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>

--- a/Tests/syntax_test_less.less
+++ b/Tests/syntax_test_less.less
@@ -961,3 +961,5 @@ a {
     color: #A1C0DE;
     color: #ABBAFADE;
 }
+
+.orderOfEvaluation(@a1, @a2, @a3) when ((@a1) and (@a2) or (@a3)) {}


### PR DESCRIPTION
Adds `or` as an option for conditional mixin guards.

Before:
![image](https://github.com/radium-v/Better-Less/assets/863023/42d3d84c-7f1c-4fa4-9b73-2ad31aa50a4e)

After:
![image](https://github.com/radium-v/Better-Less/assets/863023/47b5127f-7fac-4916-927f-7b52dbc1c7cd)

Related to microsoft/vscode#188457.