### PR TITLE
add range function

### DIFF
--- a/Syntaxes/Better Less.YAML-tmLanguage
+++ b/Syntaxes/Better Less.YAML-tmLanguage
@@ -998,6 +998,22 @@ repository:
         - include: '#property-values'
         - include: '#comma-delimiter'
         - include: '#integer-type'
+    - name: meta.function-call.less
+      begin: \b(range)(?=\()\b
+      beginCaptures:
+        '1': {name: support.function.range.less}
+      end: \)
+      endCaptures:
+        '0': {name: punctuation.definition.group.end.less}
+      patterns:
+      - begin: \(
+        beginCaptures:
+          '0': {name: punctuation.definition.group.begin.less}
+        end: (?=\))
+        patterns:
+        - include: '#property-values'
+        - include: '#comma-delimiter'
+        - include: '#integer-type'
 
   less-logical-comparisons:
     patterns:

--- a/Syntaxes/Better Less.tmLanguage
+++ b/Syntaxes/Better Less.tmLanguage
@@ -3237,6 +3237,62 @@
 						</dict>
 					</array>
 				</dict>
+				<dict>
+					<key>begin</key>
+					<string>\b(range)(?=\()\b</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>support.function.range.less</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>\)</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.group.end.less</string>
+						</dict>
+					</dict>
+					<key>name</key>
+					<string>meta.function-call.less</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>begin</key>
+							<string>\(</string>
+							<key>beginCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.definition.group.begin.less</string>
+								</dict>
+							</dict>
+							<key>end</key>
+							<string>(?=\))</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>#property-values</string>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>#comma-delimiter</string>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>#integer-type</string>
+								</dict>
+							</array>
+						</dict>
+					</array>
+				</dict>
 			</array>
 		</dict>
 		<key>less-logical-comparisons</key>

--- a/Tests/syntax_test_less.less
+++ b/Tests/syntax_test_less.less
@@ -984,3 +984,6 @@ div {
   background: @bg;
   color: if(@bg-light, black, white);
 }
+
+@value: range(4);
+@value: range(10px, 30px, 10);


### PR DESCRIPTION
Adds the `range` function.

Before:
![image](https://github.com/radium-v/Better-Less/assets/863023/0e0f2f6f-3d67-4396-b235-19ca912a8ab7)


After:
![image](https://github.com/radium-v/Better-Less/assets/863023/30c63959-a900-41bc-b039-b9e7a63b26ab)

