### PR TITLE
fix regex error

### DIFF
--- a/Syntaxes/Better Less.YAML-tmLanguage
+++ b/Syntaxes/Better Less.YAML-tmLanguage
@@ -1949,7 +1949,7 @@ repository:
           - include: '#time-type'
           - include: '#number-type'
           - name: variable.other.constant.animation-name.less
-            match: -?(?:[_a-zA-Z]|[^\x00-\x7F]|(?:(:?\\[0-9a-f]{1,6}(\r\n|[\s\t\r\n\f])?)|\\[^\r\n\f0-9a-f]))(?:[-_a-zA-Z0-9]|[^\x00-\x7F]|(?:(:?\\[0-9a-f]{1,6}(\r\n|[\t\r\n\f])?)|\\[^\r\n\f0-9a-f]))*
+            match: -?(?:[_a-zA-Z]|[^\x{00}-\x{7F}]|(?:(:?\\[0-9a-f]{1,6}(\r\n|[\s\t\r\n\f])?)|\\[^\r\n\f0-9a-f]))(?:[-_a-zA-Z0-9]|[^\x{00}-\x{7F}]|(?:(:?\\[0-9a-f]{1,6}(\r\n|[\t\r\n\f])?)|\\[^\r\n\f0-9a-f]))*
           - include: '#literal-string'
           - include: '#property-values'
           - match: \s*(?:(,))

--- a/Syntaxes/Better Less.tmLanguage
+++ b/Syntaxes/Better Less.tmLanguage
@@ -6048,7 +6048,7 @@
 										</dict>
 										<dict>
 											<key>match</key>
-											<string>-?(?:[_a-zA-Z]|[^\x00-\x7F]|(?:(:?\\[0-9a-f]{1,6}(\r\n|[\s\t\r\n\f])?)|\\[^\r\n\f0-9a-f]))(?:[-_a-zA-Z0-9]|[^\x00-\x7F]|(?:(:?\\[0-9a-f]{1,6}(\r\n|[\t\r\n\f])?)|\\[^\r\n\f0-9a-f]))*</string>
+											<string>-?(?:[_a-zA-Z]|[^\x{00}-\x{7F}]|(?:(:?\\[0-9a-f]{1,6}(\r\n|[\s\t\r\n\f])?)|\\[^\r\n\f0-9a-f]))(?:[-_a-zA-Z0-9]|[^\x{00}-\x{7F}]|(?:(:?\\[0-9a-f]{1,6}(\r\n|[\t\r\n\f])?)|\\[^\r\n\f0-9a-f]))*</string>
 											<key>name</key>
 											<string>variable.other.constant.animation-name.less</string>
 										</dict>


### PR DESCRIPTION
Sublme Text 2 throws an error when loading the extension:

```
Error loading syntax file "Packages/better-less/Syntaxes/Better Less.tmLanguage": Error in regex: too short multibyte code string in regex -?(?:[_a-zA-Z]|[^\x00-\x7F]|(?:(:?\\[0-9a-f]{1,6}(\r\n|[\s\t\r\n\f])?)|\\[^\r\n\f0-9a-f]))(?:[-_a-zA-Z0-9]|[^\x00-\x7F]|(?:(:?\\[0-9a-f]{1,6}(\r\n|[\t\r\n\f])?)|\\[^\r\n\f0-9a-f]))*
```

The `[^\x00-\x7F]` range needs to have curly braces around the values: `[^\x{00}-\x{7F}]`.

Tested in Sublime Text 2, Sublime Text 3, and VS Code 1.83.1.

Fixes #13.