### PR TITLE
add isdefined function

### DIFF
--- a/Syntaxes/Better Less.YAML-tmLanguage
+++ b/Syntaxes/Better Less.YAML-tmLanguage
@@ -1379,6 +1379,20 @@ repository:
         - include: '#comma-delimiter'
         - name: keyword.other.unit.less
           match: (?x)\b((?i:em|ex|ch|rem)|(?i:vw|vh|vmin|vmax)|(?i:cm|mm|q|in|pt|pc|px|fr)|(?i:deg|grad|rad|turn)|(?i:s|ms)|(?i:Hz|kHz)|(?i:dpi|dpcm|dppx))\b
+    - name: meta.function-call.less
+      begin: \b(isdefined)(?=\()
+      beginCaptures:
+        '1': {name: support.function.type.less}
+      end: \)
+      endCaptures:
+        '0': {name: punctuation.definition.group.end.less}
+      patterns:
+      - begin: \(
+        beginCaptures:
+          '0': {name: punctuation.definition.group.begin.less}
+        end: (?=\))
+        patterns:
+        - include: '#less-variables'
 
   less-variable-assignment:
     patterns:

--- a/Syntaxes/Better Less.tmLanguage
+++ b/Syntaxes/Better Less.tmLanguage
@@ -4534,6 +4534,54 @@
 						</dict>
 					</array>
 				</dict>
+				<dict>
+					<key>begin</key>
+					<string>\b(isdefined)(?=\()</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>support.function.type.less</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>\)</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.group.end.less</string>
+						</dict>
+					</dict>
+					<key>name</key>
+					<string>meta.function-call.less</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>begin</key>
+							<string>\(</string>
+							<key>beginCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.definition.group.begin.less</string>
+								</dict>
+							</dict>
+							<key>end</key>
+							<string>(?=\))</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>#less-variables</string>
+								</dict>
+							</array>
+						</dict>
+					</array>
+				</dict>
 			</array>
 		</dict>
 		<key>less-variable-assignment</key>

--- a/Tests/syntax_test_less.less
+++ b/Tests/syntax_test_less.less
@@ -633,6 +633,14 @@ filter: e("ms:alwaysHasItsOwnSyntax.For.Stuff()");
 //                 ^ punctuation.definition.group.begin.less
 //                  ^^^^ variable.other.readwrite.less
 //                      ^ punctuation.definition.group.end.less
+
+    @val: isdefined(@var);
+//        ^^^^^^^^^^^^^^^ meta.function-call.less
+//        ^^^^^^^^^ support.function.type.less
+//                 ^ punctuation.definition.group.begin.less
+//                  ^^^^ variable.other.readwrite.less
+//                      ^ punctuation.definition.group.end.less
+
 }
 
 /* Color Definition Functions */


### PR DESCRIPTION
Adds support for the `isdefined` function.

Before:
![image](https://github.com/radium-v/Better-Less/assets/863023/21d0cc7f-a1e0-40a6-9b01-778688d56eed)

After:
![image](https://github.com/radium-v/Better-Less/assets/863023/5546673b-9f9c-4971-a927-acfb029cb07b)

