### PR TITLE
Add `backdrop-filter` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Changelog
+
+## Unreleased
+* Add `backdrop-filter` support
+
 ## 0.6.1 - Fast Follow
 * Fix regex compatibility error for animation names in Sublime Text 2
 * Update the Changelog (oops)

--- a/Syntaxes/Better Less.YAML-tmLanguage
+++ b/Syntaxes/Better Less.YAML-tmLanguage
@@ -1987,7 +1987,7 @@ repository:
           captures:
             '1': {name: punctuation.definition.arbitrary-repetition.less}
       - name: meta.property-name.less
-        begin: \bfilter\b
+        begin: \b(?:backdrop-)?filter\b
         beginCaptures:
           '0': {name: support.type.property-name.less}
         end: \s*(;)|(?=[})])

--- a/Syntaxes/Better Less.tmLanguage
+++ b/Syntaxes/Better Less.tmLanguage
@@ -6193,7 +6193,7 @@
 						</dict>
 						<dict>
 							<key>begin</key>
-							<string>\bfilter\b</string>
+							<string>\b(?:backdrop-)?filter\b</string>
 							<key>beginCaptures</key>
 							<dict>
 								<key>0</key>

--- a/Tests/syntax_test_less.less
+++ b/Tests/syntax_test_less.less
@@ -995,3 +995,7 @@ div {
 
 @value: range(4);
 @value: range(10px, 30px, 10);
+
+.filter {
+    backdrop-filter: blur(10px);
+}


### PR DESCRIPTION
Adds the missing `backdrop-filter` property.

Closes #26.

Before:
![The backdrop-filter property with incorrect syntax highlighting](https://github.com/radium-v/Better-Less/assets/863023/227f1be5-0f5e-4071-99a3-cda5714df346)

After:
![The backdrop-filter property with correct syntax highlighting](https://github.com/radium-v/Better-Less/assets/863023/bc7e3ebd-3062-49c1-816b-062213c55a42)
