### PR TITLE
separate alignment-baseline property values

### DIFF
--- a/Syntaxes/Better Less.YAML-tmLanguage
+++ b/Syntaxes/Better Less.YAML-tmLanguage
@@ -1625,6 +1625,14 @@ repository:
           |stretch|baseline|safe|unsafe|legacy|anchor-center|first|last|self-start|self-end
         )\b
 
+    - comment: alignment-baseline
+      name: support.constant.property-value.less
+      match: |-
+        (?x)\b(?:
+          text-before-edge|before-edge|middle|central|text-after-edge
+          |after-edge|ideographic|alphabetic|hanging|mathematical|top|center|bottom
+        )\b
+
     - name: support.constant.property-value.less
       match: |-
         (?x)\b(

--- a/Syntaxes/Better Less.tmLanguage
+++ b/Syntaxes/Better Less.tmLanguage
@@ -5331,6 +5331,17 @@
 					<string>support.constant.property-value.less</string>
 				</dict>
 				<dict>
+					<key>comment</key>
+					<string>alignment-baseline</string>
+					<key>match</key>
+					<string>(?x)\b(?:
+  text-before-edge|before-edge|middle|central|text-after-edge
+  |after-edge|ideographic|alphabetic|hanging|mathematical|top|center|bottom
+)\b</string>
+					<key>name</key>
+					<string>support.constant.property-value.less</string>
+				</dict>
+				<dict>
 					<key>match</key>
 					<string>(?x)\b(
   absolute|active|add

--- a/Tests/syntax_test_less-inline-layout.less
+++ b/Tests/syntax_test_less-inline-layout.less
@@ -1,0 +1,109 @@
+// SYNTAX TEST "Packages/Better-Less/Syntaxes/Better Less.tmLanguage"
+
+.alignment-baseline {
+    alignment-baseline: auto;
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^^^^^^^^^^^^^^ support.type.property-name.less
+//                    ^ punctuation.separator.key-value.less
+//                     ^^^^^ meta.property-value.less
+//                      ^^^^ support.constant.property-value.less
+//                          ^ punctuation.terminator.rule.less
+    alignment-baseline: baseline;
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^^^^^^^^^^^^^^ support.type.property-name.less
+//                    ^ punctuation.separator.key-value.less
+//                     ^^^^^^^^^ meta.property-value.less
+//                      ^^^^^^^^ support.constant.property-value.less
+//                              ^ punctuation.terminator.rule.less
+    alignment-baseline: before-edge;
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^^^^^^^^^^^^^^ support.type.property-name.less
+//                    ^ punctuation.separator.key-value.less
+//                     ^^^^^^^^^^^^ meta.property-value.less
+//                      ^^^^^^^^^^^ support.constant.property-value.less
+//                                 ^ punctuation.terminator.rule.less
+    alignment-baseline: text-before-edge;
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^^^^^^^^^^^^^^ support.type.property-name.less
+//                    ^ punctuation.separator.key-value.less
+//                     ^^^^^^^^^^^^^^^^^ meta.property-value.less
+//                      ^^^^^^^^^^^^^^^^ support.constant.property-value.less
+//                                      ^ punctuation.terminator.rule.less
+    alignment-baseline: middle;
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^^^^^^^^^^^^^^ support.type.property-name.less
+//                    ^ punctuation.separator.key-value.less
+//                     ^^^^^^^ meta.property-value.less
+//                      ^^^^^^ support.constant.property-value.less
+//                            ^ punctuation.terminator.rule.less
+    alignment-baseline: central;
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^^^^^^^^^^^^^^ support.type.property-name.less
+//                    ^ punctuation.separator.key-value.less
+//                     ^^^^^^^^ meta.property-value.less
+//                      ^^^^^^^ support.constant.property-value.less
+//                             ^ punctuation.terminator.rule.less
+    alignment-baseline: after-edge;
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^^^^^^^^^^^^^^ support.type.property-name.less
+//                    ^ punctuation.separator.key-value.less
+//                     ^^^^^^^^^^^ meta.property-value.less
+//                      ^^^^^^^^^^ support.constant.property-value.less
+//                                ^ punctuation.terminator.rule.less
+    alignment-baseline: text-after-edge;
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^^^^^^^^^^^^^^ support.type.property-name.less
+//                    ^ punctuation.separator.key-value.less
+//                     ^^^^^^^^^^^^^^^^ meta.property-value.less
+//                      ^^^^^^^^^^^^^^^ support.constant.property-value.less
+//                                     ^ punctuation.terminator.rule.less
+    alignment-baseline: ideographic;
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^^^^^^^^^^^^^^ support.type.property-name.less
+//                    ^ punctuation.separator.key-value.less
+//                     ^^^^^^^^^^^^ meta.property-value.less
+//                      ^^^^^^^^^^^ support.constant.property-value.less
+//                                 ^ punctuation.terminator.rule.less
+    alignment-baseline: alphabetic;
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^^^^^^^^^^^^^^ support.type.property-name.less
+//                    ^ punctuation.separator.key-value.less
+//                     ^^^^^^^^^^^ meta.property-value.less
+//                      ^^^^^^^^^^ support.constant.property-value.less
+//                                ^ punctuation.terminator.rule.less
+    alignment-baseline: hanging;
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^^^^^^^^^^^^^^ support.type.property-name.less
+//                    ^ punctuation.separator.key-value.less
+//                     ^^^^^^^^ meta.property-value.less
+//                      ^^^^^^^ support.constant.property-value.less
+//                             ^ punctuation.terminator.rule.less
+    alignment-baseline: mathematical;
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^^^^^^^^^^^^^^ support.type.property-name.less
+//                    ^ punctuation.separator.key-value.less
+//                     ^^^^^^^^^^^^^ meta.property-value.less
+//                      ^^^^^^^^^^^^ support.constant.property-value.less
+//                                  ^ punctuation.terminator.rule.less
+    alignment-baseline: top;
+//^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^^^^^^^^^^^^^^ support.type.property-name.less
+//                    ^ punctuation.separator.key-value.less
+//                     ^^^^ meta.property-value.less
+//                      ^^^ support.constant.property-value.less
+//                         ^ punctuation.terminator.rule.less
+    alignment-baseline: center;
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^^^^^^^^^^^^^^ support.type.property-name.less
+//                    ^ punctuation.separator.key-value.less
+//                     ^^^^^^^ meta.property-value.less
+//                      ^^^^^^ support.constant.property-value.less
+//                            ^ punctuation.terminator.rule.less
+    alignment-baseline: bottom;
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^^^^^^^^^^^^^^ support.type.property-name.less
+//                    ^ punctuation.separator.key-value.less
+//                     ^^^^^^^ meta.property-value.less
+//                      ^^^^^^ support.constant.property-value.less
+//                            ^ punctuation.terminator.rule.less
+}


### PR DESCRIPTION
- separates values for the `alignment-baseline` SVG property into its own block
- adds inline-layout test file