### PR TITLE
separate values for the `all` property

### DIFF
--- a/Syntaxes/Better Less.YAML-tmLanguage
+++ b/Syntaxes/Better Less.YAML-tmLanguage
@@ -1633,6 +1633,10 @@ repository:
           |after-edge|ideographic|alphabetic|hanging|mathematical|top|center|bottom
         )\b
 
+    - comment: all/global values
+      name: support.constant.property-value.less
+      match: \b(?:initial|inherit|unset|revert-layer|revert)\b
+
     - name: support.constant.property-value.less
       match: |-
         (?x)\b(

--- a/Syntaxes/Better Less.tmLanguage
+++ b/Syntaxes/Better Less.tmLanguage
@@ -5342,6 +5342,14 @@
 					<string>support.constant.property-value.less</string>
 				</dict>
 				<dict>
+					<key>comment</key>
+					<string>all/global values</string>
+					<key>match</key>
+					<string>\b(?:initial|inherit|unset|revert-layer|revert)\b</string>
+					<key>name</key>
+					<string>support.constant.property-value.less</string>
+				</dict>
+				<dict>
 					<key>match</key>
 					<string>(?x)\b(
   absolute|active|add

--- a/Tests/syntax_test_less-all.less
+++ b/Tests/syntax_test_less-all.less
@@ -1,0 +1,39 @@
+// SYNTAX TEST "Packages/Better-Less/Syntaxes/Better Less.tmLanguage"
+
+.all {
+    all: initial;
+//^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^ support.type.property-name.less
+//     ^ punctuation.separator.key-value.less
+//      ^^^^^^^^ meta.property-value.less
+//       ^^^^^^^ support.constant.property-value.less
+//              ^ punctuation.terminator.rule.less
+    all: inherit;
+//^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^ support.type.property-name.less
+//     ^ punctuation.separator.key-value.less
+//      ^^^^^^^^ meta.property-value.less
+//       ^^^^^^^ support.constant.property-value.less
+//              ^ punctuation.terminator.rule.less
+    all: unset;
+//^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^ support.type.property-name.less
+//     ^ punctuation.separator.key-value.less
+//      ^^^^^^ meta.property-value.less
+//       ^^^^^ support.constant.property-value.less
+//            ^ punctuation.terminator.rule.less
+    all: revert;
+//^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^ support.type.property-name.less
+//     ^ punctuation.separator.key-value.less
+//      ^^^^^^^ meta.property-value.less
+//       ^^^^^^ support.constant.property-value.less
+//             ^ punctuation.terminator.rule.less
+    all: revert-layer;
+//^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^ support.type.property-name.less
+//     ^ punctuation.separator.key-value.less
+//      ^^^^^^^^^^^^^ meta.property-value.less
+//       ^^^^^^^^^^^^ support.constant.property-value.less
+//                   ^ punctuation.terminator.rule.less
+}


### PR DESCRIPTION
These properties are global, but the only valid values for the all property.