### PR TITLE
Fix units on 0

### DIFF
--- a/Syntaxes/Better Less.YAML-tmLanguage
+++ b/Syntaxes/Better Less.YAML-tmLanguage
@@ -693,8 +693,8 @@ repository:
       - include: '#less-variables'
       - include: '#var-function'
       - include: '#calc-function'
-      - include: '#length-type'
       - include: '#percentage-type'
+      - include: '#length-type'
 
   format-function:
     patterns:
@@ -844,10 +844,14 @@ repository:
       '1': {name: punctuation.definition.arbitrary-repetition.less}
 
   length-type:
-    name: constant.numeric.less
-    match: (?:[-+]?)(?:\d+\.\d+|\.?\d+)(?:[eE][-+]?\d+)?(em|ex|ch|rem|vw|vh|vmin|vmax|cm|mm|m|q|in|pt|pc|px|fr|dpi|dpcm|dppx|x)?
-    captures:
-      '1': {name: keyword.other.unit.less}
+    patterns:
+    - name: constant.numeric.less
+      match: (?:[-+]?)(?:\d+\.\d+|\.?\d+)(?:[eE][-+]?\d+)?(em|ex|ch|rem|vw|vh|vmin|vmax|cm|mm|m|q|in|pt|pc|px|fr|dpi|dpcm|dppx|x)
+      captures:
+        '1': {name: keyword.other.unit.less}
+    - name: constant.numeric.less
+      match: \b(?:[-+]?)0\b
+
 
   less-boolean-function:
     name: meta.function-call.less
@@ -2832,8 +2836,8 @@ repository:
       patterns:
       - name: support.constant.property-value.less
         match: block|inline|x|y|auto
-      - include: '#length-type'
       - include: '#percentage-type'
+      - include: '#length-type'
       - include: '#less-variables'
       - include: '#var-function'
       - include: '#calc-function'

--- a/Syntaxes/Better Less.YAML-tmLanguage
+++ b/Syntaxes/Better Less.YAML-tmLanguage
@@ -1399,17 +1399,11 @@ repository:
       patterns:
       - include: '#less-variable-assignment'
       - include: '#comma-delimiter'
-      - match: \s*(;)|(?=[})])
-        captures:
-          '1': {name: punctuation.terminator.rule.less}
       - include: '#property-values'
       - include: '#rule-list-body'
-
-  less-number-units:
-    patterns:
-    - name: keyword.other.unit.less
-      match: \b((c|m)?m|in|p(t|c)|m?s|g?rad|deg|turn)\b
-    - match: \b(r?em|ex|ch|vw|vh|vmin|vmax|cm|mm|q|in|pt|pc|px|fr|s|ms|Hz|kHz|dpi|dpcm|dppx|deg|grad|rad|turn)\b
+    - match: (;)|(?=[})])
+      captures:
+        '1': {name: punctuation.terminator.rule.less}
 
   less-string-functions:
     patterns:
@@ -2082,7 +2076,22 @@ repository:
     - include: '#comment-line'
     - include: '#at-rules'
     - include: '#less-variable-assignment'
-    - include: '#less-variable-interpolation'
+    - begin: (?=[-\w]*?@\{.*\}[-\w]*?\s*:[^;{(]*(?=[;})]))
+      end: (?=\s*(;)|(?=[})]))
+      patterns:
+      - begin: (?=[^\s:])
+        end: (?=(((\+_?)?):)[\s\t]*)
+        name: support.type.property-name.less
+        patterns:
+        - include: '#less-variable-interpolation'
+      - contentName: meta.property-value.less
+        begin: (((\+_?)?):)(?=[\s\t]*)
+        contentName: support.type.property-name.less
+        beginCaptures:
+          '1': {name: punctuation.separator.key-value.less}
+        end: (?=\s*(;)|(?=[})]))
+        patterns:
+        - include: '#property-values'
     - begin: (?=[-a-z])
       end: $|(?![-a-z])
       patterns:

--- a/Syntaxes/Better Less.YAML-tmLanguage
+++ b/Syntaxes/Better Less.YAML-tmLanguage
@@ -591,7 +591,7 @@ repository:
     - include: '#frequency-type'
     - include: '#time-type'
     - include: '#length-type'
-    - include: '#resolution-type'
+    - include: '#percentage-type'
 
   filter-function:
     name: meta.function-call.less
@@ -845,7 +845,7 @@ repository:
 
   length-type:
     name: constant.numeric.less
-    match: 0|(?i:[-+]?(?:(?:\d*\.\d+(?:[eE](?:[-+]?\d+))*)|(?:[-+]?\d+))(em|ex|ch|rem|vw|vh|vmin|vmax|(c|m)?m|q|in|pt|pc|px|fr))\b
+    match: (?:[-+]?)(?:\d+\.\d+|\.?\d+)(?:[eE][-+]?\d+)?(em|ex|ch|rem|vw|vh|vmin|vmax|cm|mm|m|q|in|pt|pc|px|fr|dpi|dpcm|dppx|x)?
     captures:
       '1': {name: keyword.other.unit.less}
 
@@ -1272,7 +1272,6 @@ repository:
         end: (?=\))
         patterns:
         - include: '#less-variables'
-        - include: '#dimensions'
         - include: '#numeric-values'
         - include: '#literal-string'
         - include: '#comma-delimiter'
@@ -1688,7 +1687,7 @@ repository:
 
   number-type:
     name: constant.numeric.less
-    match: '[-+]?(?:(?:\d*\.\d+(?:[eE](?:[-+]?\d+))*)|(?:[-+]?\d+))'
+    match: (?:[-+]?)(?:\d+\.\d+|\.?\d+)(?:[eE][-+]?\d+)?
 
   numeric-values:
     patterns:
@@ -1698,7 +1697,7 @@ repository:
 
   percentage-type:
     name: constant.numeric.less
-    match: '[-+]?(?:(?:\d*\.\d+(?:[eE](?:[-+]?\d+))*)|(?:[-+]?\d+))(%)'
+    match: (?:[-+]?)(?:\d+\.\d+|\.?\d+)(?:[eE][-+]?\d+)?(%)
     captures:
       '1': {name: keyword.other.unit.less}
 
@@ -2049,12 +2048,6 @@ repository:
       match: from
     - name: keyword.other.less
       match: \b[hslawbch]\b
-
-  resolution-type:
-    name: constant.numeric.less
-    match: (?i:[-+]?(?:(?:\d*\.\d+(?:[eE](?:[-+]?\d+))*)|(?:[-+]?\d+))(dpi|dpcm|dppx))\b
-    captures:
-      '1': {name: keyword.other.unit.less}
 
   rule-list:
     patterns:

--- a/Syntaxes/Better Less.YAML-tmLanguage
+++ b/Syntaxes/Better Less.YAML-tmLanguage
@@ -590,8 +590,8 @@ repository:
     - include: '#angle-type'
     - include: '#frequency-type'
     - include: '#time-type'
-    - include: '#length-type'
     - include: '#percentage-type'
+    - include: '#length-type'
 
   filter-function:
     name: meta.function-call.less

--- a/Syntaxes/Better Less.tmLanguage
+++ b/Syntaxes/Better Less.tmLanguage
@@ -2253,11 +2253,11 @@
 						</dict>
 						<dict>
 							<key>include</key>
-							<string>#length-type</string>
+							<string>#percentage-type</string>
 						</dict>
 						<dict>
 							<key>include</key>
-							<string>#percentage-type</string>
+							<string>#length-type</string>
 						</dict>
 					</array>
 				</dict>
@@ -2724,18 +2724,29 @@
 		</dict>
 		<key>length-type</key>
 		<dict>
-			<key>captures</key>
-			<dict>
-				<key>1</key>
+			<key>patterns</key>
+			<array>
 				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.unit.less</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>(?:[-+]?)(?:\d+\.\d+|\.?\d+)(?:[eE][-+]?\d+)?(em|ex|ch|rem|vw|vh|vmin|vmax|cm|mm|m|q|in|pt|pc|px|fr|dpi|dpcm|dppx|x)</string>
 					<key>name</key>
-					<string>keyword.other.unit.less</string>
+					<string>constant.numeric.less</string>
 				</dict>
-			</dict>
-			<key>match</key>
-			<string>(?:[-+]?)(?:\d+\.\d+|\.?\d+)(?:[eE][-+]?\d+)?(em|ex|ch|rem|vw|vh|vmin|vmax|cm|mm|m|q|in|pt|pc|px|fr|dpi|dpcm|dppx|x)?</string>
-			<key>name</key>
-			<string>constant.numeric.less</string>
+				<dict>
+					<key>match</key>
+					<string>\b(?:[-+]?)0\b</string>
+					<key>name</key>
+					<string>constant.numeric.less</string>
+				</dict>
+			</array>
 		</dict>
 		<key>less-boolean-function</key>
 		<dict>
@@ -8697,11 +8708,11 @@
 						</dict>
 						<dict>
 							<key>include</key>
-							<string>#length-type</string>
+							<string>#percentage-type</string>
 						</dict>
 						<dict>
 							<key>include</key>
-							<string>#percentage-type</string>
+							<string>#length-type</string>
 						</dict>
 						<dict>
 							<key>include</key>

--- a/Syntaxes/Better Less.tmLanguage
+++ b/Syntaxes/Better Less.tmLanguage
@@ -1913,11 +1913,11 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#length-type</string>
+					<string>#percentage-type</string>
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#resolution-type</string>
+					<string>#length-type</string>
 				</dict>
 			</array>
 		</dict>
@@ -2401,11 +2401,11 @@
 								</dict>
 								<dict>
 									<key>include</key>
-									<string>#percentage-type</string>
+									<string>#length-type</string>
 								</dict>
 								<dict>
 									<key>include</key>
-									<string>#length-type</string>
+									<string>#percentage-type</string>
 								</dict>
 								<dict>
 									<key>include</key>
@@ -2733,7 +2733,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>0|(?i:[-+]?(?:(?:\d*\.\d+(?:[eE](?:[-+]?\d+))*)|(?:[-+]?\d+))(em|ex|ch|rem|vw|vh|vmin|vmax|(c|m)?m|q|in|pt|pc|px|fr))\b</string>
+			<string>(?:[-+]?)(?:\d+\.\d+|\.?\d+)(?:[eE][-+]?\d+)?(em|ex|ch|rem|vw|vh|vmin|vmax|cm|mm|m|q|in|pt|pc|px|fr|dpi|dpcm|dppx|x)?</string>
 			<key>name</key>
 			<string>constant.numeric.less</string>
 		</dict>
@@ -4151,10 +4151,6 @@
 								</dict>
 								<dict>
 									<key>include</key>
-									<string>#dimensions</string>
-								</dict>
-								<dict>
-									<key>include</key>
 									<string>#numeric-values</string>
 								</dict>
 								<dict>
@@ -4594,18 +4590,6 @@
 							<string>#comma-delimiter</string>
 						</dict>
 						<dict>
-							<key>captures</key>
-							<dict>
-								<key>1</key>
-								<dict>
-									<key>name</key>
-									<string>punctuation.terminator.rule.less</string>
-								</dict>
-							</dict>
-							<key>match</key>
-							<string>\s*(;)|(?=[})])</string>
-						</dict>
-						<dict>
 							<key>include</key>
 							<string>#property-values</string>
 						</dict>
@@ -4615,21 +4599,17 @@
 						</dict>
 					</array>
 				</dict>
-			</array>
-		</dict>
-		<key>less-number-units</key>
-		<dict>
-			<key>patterns</key>
-			<array>
 				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.terminator.rule.less</string>
+						</dict>
+					</dict>
 					<key>match</key>
-					<string>\b((c|m)?m|in|p(t|c)|m?s|g?rad|deg|turn)\b</string>
-					<key>name</key>
-					<string>keyword.other.unit.less</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>\b(r?em|ex|ch|vw|vh|vmin|vmax|cm|mm|q|in|pt|pc|px|fr|s|ms|Hz|kHz|dpi|dpcm|dppx|deg|grad|rad|turn)\b</string>
+					<string>(;)|(?=[})])</string>
 				</dict>
 			</array>
 		</dict>
@@ -5585,7 +5565,7 @@
 		<key>number-type</key>
 		<dict>
 			<key>match</key>
-			<string>[-+]?(?:(?:\d*\.\d+(?:[eE](?:[-+]?\d+))*)|(?:[-+]?\d+))</string>
+			<string>(?:[-+]?)(?:\d+\.\d+|\.?\d+)(?:[eE][-+]?\d+)?</string>
 			<key>name</key>
 			<string>constant.numeric.less</string>
 		</dict>
@@ -5618,7 +5598,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>[-+]?(?:(?:\d*\.\d+(?:[eE](?:[-+]?\d+))*)|(?:[-+]?\d+))(%)</string>
+			<string>(?:[-+]?)(?:\d+\.\d+|\.?\d+)(?:[eE][-+]?\d+)?(%)</string>
 			<key>name</key>
 			<string>constant.numeric.less</string>
 		</dict>
@@ -6366,21 +6346,6 @@
 				</dict>
 			</array>
 		</dict>
-		<key>resolution-type</key>
-		<dict>
-			<key>captures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>keyword.other.unit.less</string>
-				</dict>
-			</dict>
-			<key>match</key>
-			<string>(?i:[-+]?(?:(?:\d*\.\d+(?:[eE](?:[-+]?\d+))*)|(?:[-+]?\d+))(dpi|dpcm|dppx))\b</string>
-			<key>name</key>
-			<string>constant.numeric.less</string>
-		</dict>
 		<key>rule-list</key>
 		<dict>
 			<key>patterns</key>
@@ -6447,8 +6412,51 @@
 					<string>#less-variable-assignment</string>
 				</dict>
 				<dict>
-					<key>include</key>
-					<string>#less-variable-interpolation</string>
+					<key>begin</key>
+					<string>(?=[-\w]*?@\{.*\}[-\w]*?\s*:[^;{(]*(?=[;})]))</string>
+					<key>end</key>
+					<string>(?=\s*(;)|(?=[})]))</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>begin</key>
+							<string>(?=[^\s:])</string>
+							<key>end</key>
+							<string>(?=(((\+_?)?):)[\s\t]*)</string>
+							<key>name</key>
+							<string>support.type.property-name.less</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>#less-variable-interpolation</string>
+								</dict>
+							</array>
+						</dict>
+						<dict>
+							<key>begin</key>
+							<string>(((\+_?)?):)(?=[\s\t]*)</string>
+							<key>beginCaptures</key>
+							<dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.separator.key-value.less</string>
+								</dict>
+							</dict>
+							<key>contentName</key>
+							<string>support.type.property-name.less</string>
+							<key>end</key>
+							<string>(?=\s*(;)|(?=[})]))</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>#property-values</string>
+								</dict>
+							</array>
+						</dict>
+					</array>
 				</dict>
 				<dict>
 					<key>begin</key>

--- a/Syntaxes/Better Less.tmLanguage
+++ b/Syntaxes/Better Less.tmLanguage
@@ -2401,11 +2401,11 @@
 								</dict>
 								<dict>
 									<key>include</key>
-									<string>#length-type</string>
+									<string>#percentage-type</string>
 								</dict>
 								<dict>
 									<key>include</key>
-									<string>#percentage-type</string>
+									<string>#length-type</string>
 								</dict>
 								<dict>
 									<key>include</key>

--- a/Tests/syntax_test_less-value-units.less
+++ b/Tests/syntax_test_less-value-units.less
@@ -1,0 +1,162 @@
+// SYNTAX TEST "Packages/Better-Less/Syntaxes/Better Less.tmLanguage"
+
+.number {
+    column-count: 3;
+//^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^^^^^^^^ support.type.property-name.less
+//              ^ punctuation.separator.key-value.less
+//               ^^ meta.property-value.less
+//                ^ constant.numeric.less
+//                 ^ punctuation.terminator.rule.less
+    z-index: 1;
+//^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^^^ support.type.property-name.less
+//         ^ punctuation.separator.key-value.less
+//          ^^ meta.property-value.less
+//           ^ constant.numeric.less
+//            ^ punctuation.terminator.rule.less
+    opacity: 0.5;
+//^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^^^ support.type.property-name.less
+//         ^ punctuation.separator.key-value.less
+//          ^^^^ meta.property-value.less
+//           ^^^ constant.numeric.less
+//              ^ punctuation.terminator.rule.less
+    opacity: 0;
+//^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^^^ support.type.property-name.less
+//         ^ punctuation.separator.key-value.less
+//          ^^ meta.property-value.less
+//           ^ constant.numeric.less
+//            ^ punctuation.terminator.rule.less
+
+}
+
+.percentage {
+    width: -0%;
+//^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^ support.type.property-name.less
+//       ^ punctuation.separator.key-value.less
+//        ^^^^ meta.property-value.less
+//         ^^^ constant.numeric.less
+//           ^ keyword.other.unit.less
+//            ^ punctuation.terminator.rule.less
+    width: 0%;
+//^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^ support.type.property-name.less
+//       ^ punctuation.separator.key-value.less
+//        ^^^ meta.property-value.less
+//         ^^ constant.numeric.less
+//          ^ keyword.other.unit.less
+//           ^ punctuation.terminator.rule.less
+    width: +0%;
+//^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^ support.type.property-name.less
+//       ^ punctuation.separator.key-value.less
+//        ^^^^ meta.property-value.less
+//         ^^^ constant.numeric.less
+//           ^ keyword.other.unit.less
+//            ^ punctuation.terminator.rule.less
+    width: 10%;
+//^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^ support.type.property-name.less
+//       ^ punctuation.separator.key-value.less
+//        ^^^^ meta.property-value.less
+//         ^^^ constant.numeric.less
+//           ^ keyword.other.unit.less
+//            ^ punctuation.terminator.rule.less
+    width: 10.5%;
+//^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^ support.type.property-name.less
+//       ^ punctuation.separator.key-value.less
+//        ^^^^^^ meta.property-value.less
+//         ^^^^^ constant.numeric.less
+//             ^ keyword.other.unit.less
+//              ^ punctuation.terminator.rule.less
+    width: 100%;
+//^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^ support.type.property-name.less
+//       ^ punctuation.separator.key-value.less
+//        ^^^^^ meta.property-value.less
+//         ^^^^ constant.numeric.less
+//            ^ keyword.other.unit.less
+//             ^ punctuation.terminator.rule.less
+    width: -100%;
+//^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^ support.type.property-name.less
+//       ^ punctuation.separator.key-value.less
+//        ^^^^^^ meta.property-value.less
+//         ^^^^^ constant.numeric.less
+//             ^ keyword.other.unit.less
+//              ^ punctuation.terminator.rule.less
+}
+
+.ratio {
+    aspect-ratio: 16 / 9;
+//^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^^^^^^^^ support.type.property-name.less
+//              ^ punctuation.separator.key-value.less
+//               ^^^^^^^ meta.property-value.less
+//                ^^ constant.numeric.less
+//                   ^ keyword.operator.arithmetic.less
+//                     ^ constant.numeric.less
+//                      ^ punctuation.terminator.rule.less
+    aspect-ratio: 1.7777777777777777;
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^^^^^^^^ support.type.property-name.less
+//              ^ punctuation.separator.key-value.less
+//               ^^^^^^^^^^^^^^^^^^^ meta.property-value.less
+//                ^^^^^^^^^^^^^^^^^^ constant.numeric.less
+//                                  ^ punctuation.terminator.rule.less
+}
+
+@media print and (min-resolution: 300dpi) {}
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.media.less
+//^^^^ keyword.control.at-rule.media.less
+//     ^^^^^ support.constant.media.less
+//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group.less
+//           ^^^ keyword.operator.logic.media.less
+//               ^ punctuation.definition.group.begin.less
+//                ^^^^^^^^^^^^^^ support.type.property-name.media.less
+//                              ^ punctuation.separator.key-value.less
+//                                ^^^^^^ constant.numeric.less
+//                                   ^^^ keyword.other.unit.less
+//                                      ^ punctuation.definition.group.end.less
+//                                        ^ punctuation.definition.block.begin.less
+//                                         ^ punctuation.definition.block.end.less
+@media (resolution: 120dpcm) {}
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.media.less
+//^^^^ keyword.control.at-rule.media.less
+//     ^^^^^^^^^^^^^^^^^^^^^ meta.group.less
+//     ^ punctuation.definition.group.begin.less
+//      ^^^^^^^^^^ support.type.property-name.media.less
+//                ^ punctuation.separator.key-value.less
+//                  ^^^^^^^ constant.numeric.less
+//                     ^^^^ keyword.other.unit.less
+//                         ^ punctuation.definition.group.end.less
+//                           ^ punctuation.definition.block.begin.less
+//                            ^ punctuation.definition.block.end.less
+@media (min-resolution: 2dppx) {}
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.media.less
+//^^^^ keyword.control.at-rule.media.less
+//     ^^^^^^^^^^^^^^^^^^^^^^^ meta.group.less
+//     ^ punctuation.definition.group.begin.less
+//      ^^^^^^^^^^^^^^ support.type.property-name.media.less
+//                    ^ punctuation.separator.key-value.less
+//                      ^^^^^ constant.numeric.less
+//                       ^^^^ keyword.other.unit.less
+//                           ^ punctuation.definition.group.end.less
+//                             ^ punctuation.definition.block.begin.less
+//                              ^ punctuation.definition.block.end.less
+@media (resolution: 1x) {}
+//^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.media.less
+//^^^^ keyword.control.at-rule.media.less
+//     ^^^^^^^^^^^^^^^^ meta.group.less
+//     ^ punctuation.definition.group.begin.less
+//      ^^^^^^^^^^ support.type.property-name.media.less
+//                ^ punctuation.separator.key-value.less
+//                  ^^ constant.numeric.less
+//                   ^ keyword.other.unit.less
+//                    ^ punctuation.definition.group.end.less
+//                      ^ punctuation.definition.block.begin.less
+//                       ^ punctuation.definition.block.end.less

--- a/Tests/syntax_test_less.less
+++ b/Tests/syntax_test_less.less
@@ -15,9 +15,15 @@
 
 /* Variables */
    @nice-blue: #5B83AD;
-// ^^^^^^^^^^           variable.other.less
-// ^                    punctuation.definition.variable.less
-//  ^^^^^^^^^           support.other.variable.less
+// ^^^^^^^^^^^^^^^^^^^^ meta.property-value.less
+// ^^^^^^^^^^ variable.other.readwrite.less
+// ^ punctuation.definition.variable.less
+//  ^^^^^^^^^ support.other.variable.less
+//           ^ punctuation.separator.key-value.less
+//            ^ meta.property-value.less
+//             ^^^^^^^ constant.other.color.rgb-value.less
+//             ^ punctuation.definition.constant.less
+//                    ^ punctuation.terminator.rule.less
 
 @light-blue: @nice-blue + #111;
 //         ^                    punctuation.separator.key-value.less
@@ -110,8 +116,33 @@
 }
 
  .widget {
+   @{property}:active {}
+//^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+// ^^^^^^^^^^^^^^^^^^^ meta.selector.less
+// ^^^^^^^^^^^ variable.other.readwrite.less
+// ^ punctuation.definition.variable.less
+//  ^ punctuation.definition.expression.less
+//   ^^^^^^^^ support.other.variable.less
+//           ^ punctuation.definition.expression.less
+//            ^^^^^^^ meta.function-call.less
+//            ^ punctuation.definition.entity.less
+//             ^^^^^^ entity.other.attribute-name.pseudo-class.less
+//                    ^ meta.property-list.less punctuation.definition.block.begin.less
+//                     ^ punctuation.definition.block.end.less
    @{property}: #0ee;
+//^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+// ^^^^^^^^^^^ support.type.property-name.less variable.other.readwrite.less
+// ^ punctuation.definition.variable.less
+//  ^ punctuation.definition.expression.less
+//   ^^^^^^^^ support.other.variable.less
+//           ^ punctuation.definition.expression.less
+//            ^ punctuation.separator.key-value.less
+//             ^^^^^ support.type.property-name.less
+//              ^^^^ constant.other.color.rgb-value.less
+//              ^ punctuation.definition.constant.less
+//                  ^ punctuation.terminator.rule.less
    background-@{property}: #999;
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
 // ^^^^^^^^^^^^^^^^^^^^^^ support.type.property-name.less
 //            ^^^^^^^^^^^ variable.other.readwrite.less
 //            ^ punctuation.definition.variable.less
@@ -119,17 +150,31 @@
 //              ^^^^^^^^ support.other.variable.less
 //                      ^ punctuation.definition.expression.less
 //                       ^ punctuation.separator.key-value.less
+//                        ^^^^^ support.type.property-name.less
+//                         ^^^^ constant.other.color.rgb-value.less
+//                         ^ punctuation.definition.constant.less
+//                             ^ punctuation.terminator.rule.less
 
  }
 
-#header {
-// <- entity.other.attribute-name.id.less punctuation.definition.entity.less
-// ^                   punctuation.definition.entity.less
-//         ^           punctuation.definition.block.begin.less
+  #header {
+//^^^^^^^^ meta.selector.less
+//^^^^^^^ entity.other.attribute-name.id.less
+//^ punctuation.definition.entity.less
+//        ^ meta.property-list.less punctuation.definition.block.begin.less
+
+
 
 // <-                  meta.property-list.less
    color: @light-blue;
-//        ^^^^^^^^^^^  variable.other.less
+//^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+// ^^^^^ support.type.property-name.less
+//      ^ punctuation.separator.key-value.less
+//       ^^^^^^^^^^^^ meta.property-value.less
+//        ^^^^^^^^^^^ variable.other.readwrite.less
+//        ^ punctuation.definition.variable.less
+//         ^^^^^^^^^^ support.other.variable.less
+//                   ^ punctuation.terminator.rule.less
 }
 // <-                  punctuation.definition.block.end.less
 
@@ -165,19 +210,54 @@
 
 /* Guarded Namespaces */
 #namespace when (@mode=huge) not (default()) { }
-//         ^^^^^^^^^^^^^^^^^^^^^ meta.conditional.guarded-namespace.less
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.selector.less
+//^^^^^^^^ entity.other.attribute-name.id.less
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.conditional.guarded-namespace.less
 //         ^^^^ keyword.control.conditional.less
+//              ^^^^^^^^^^^ meta.group.less
 //              ^ punctuation.definition.group.begin.less
+//               ^^^^^ variable.other.readwrite.less
+//               ^ punctuation.definition.variable.less
+//                ^^^^ support.other.variable.less
 //                    ^ keyword.operator.logical.less
+//                     ^^^^ string.unquoted.less
 //                         ^ punctuation.definition.group.end.less
-//                            ^ meta.block.less
+//                           ^^^ keyword.operator.logical.less
+//                               ^^^^^^^^^^ meta.group.less
+//                               ^ punctuation.definition.group.begin.less
+//                                ^^^^^^^^^ support.function.default.less
+//                                       ^^ meta.group.less
+//                                       ^ punctuation.definition.group.begin.less
+//                                        ^ punctuation.definition.group.end.less
+//                                         ^ punctuation.definition.group.end.less
+//                                           ^ meta.property-list.less punctuation.definition.block.begin.less
+//                                             ^ punctuation.definition.block.end.less
 
 .mixin() when not () and (default()), () { }
-// <- meta.function-call.less
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.selector.less
+//^^^^ entity.other.attribute-name.class.less
+//    ^^ meta.group.less
+//    ^ punctuation.definition.group.begin.less
+//     ^ punctuation.definition.group.end.less
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.conditional.guarded-namespace.less
+//       ^^^^ keyword.control.conditional.less
 //            ^^^ keyword.operator.logical.less
+//                ^ meta.group.less punctuation.definition.group.begin.less
+//                 ^ punctuation.definition.group.end.less
 //                   ^^^ keyword.operator.logical.less
-//                        ^^^^^^^^^ constant.language.default.less
-//                                  ^ punctuation.separator.less
+//                       ^^^^^^^^^^ meta.group.less
+//                       ^ punctuation.definition.group.begin.less
+//                        ^^^^^^^^^ support.function.default.less
+//                               ^^ meta.group.less
+//                               ^ punctuation.definition.group.begin.less
+//                                ^ punctuation.definition.group.end.less
+//                                 ^ punctuation.definition.group.end.less
+//                                  ^ punctuation.definition.block.end.less
+//                                    ^^ meta.group.less
+//                                    ^ punctuation.definition.group.begin.less
+//                                     ^ punctuation.definition.group.end.less
+//                                       ^ meta.property-list.less punctuation.definition.block.begin.less
+//                                         ^ punctuation.definition.block.end.less
 
 .a + .b ~ .c > .d {
 // ^ punctuation.separator.combinator.less
@@ -197,23 +277,37 @@
 #header {
   .navigation {
     &.class::after { }
+//^^^^^^^^^^^^^^^^^^^^ meta.property-list.less meta.property-list.less
+//  ^^^^^^^^^^^^^^^ meta.selector.less
 //  ^ entity.other.attribute-name.parent.less punctuation.definition.entity.less
 //   ^^^^^^ entity.other.attribute-name.class.less
+//   ^ punctuation.definition.entity.less
+//         ^^^^^^^ entity.other.attribute-name.pseudo-element.less
 //         ^^ punctuation.definition.entity.less
-//                  ^ meta.property-list.less meta.property-list.less meta.property-list.less
+//                 ^ meta.property-list.less punctuation.definition.block.begin.less
+//                   ^ punctuation.definition.block.end.less
 
     &-class { }
-//  ^^^^^^^ meta.selector.less
-//  ^ entity.other.attribute-name.parent.less punctuation.definition.entity.less
-//   ^^^^^^ entity.other.attribute-name.less
+//^^^^^^^^^^^^^ meta.property-list.less meta.property-list.less
+//  ^^^^^^^^ meta.selector.less
+//  ^^^^^^^ entity.other.attribute-name.parent.less
+//  ^ punctuation.definition.entity.less
+//          ^ meta.property-list.less punctuation.definition.block.begin.less
+//            ^ punctuation.definition.block.end.less
 
     &-@{interpolated}-selector { }
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.selector.less
-//  ^ entity.other.attribute-name.parent.less punctuation.definition.entity.less
-//   ^^^^^^^^^^^^^^^^^^^^^^^^^ entity.other.attribute-name.less
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less meta.property-list.less
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.selector.less
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^ entity.other.attribute-name.parent.less
+//  ^ punctuation.definition.entity.less
+//   ^^^^^^^^^^^^^^^^^^^^^^^^^ entity.other.attribute-name.parent.less
 //    ^^^^^^^^^^^^^^^ variable.other.readwrite.less
-  }
-// <- meta.property-list.less meta.property-list.less
+//    ^ punctuation.definition.variable.less
+//     ^ punctuation.definition.expression.less
+//      ^^^^^^^^^^^^ support.other.variable.less
+//                  ^ punctuation.definition.expression.less
+//                             ^ meta.property-list.less punctuation.definition.block.begin.less
+//                               ^ punctuation.definition.block.end.less
 }
 
    .nested-media-query {
@@ -284,10 +378,16 @@
 /* Escaping */
 .weird-element {
   content: ~"^//* some horrible but needed css hack";
-//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.raw.inline.less string.quoted.other.less
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//^^^^^^^ support.type.property-name.less
+//       ^ punctuation.separator.key-value.less
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-value.less
+//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.other.less
 //         ^ constant.character.escape.less
 //          ^ punctuation.definition.string.begin.less
+//           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.raw.inline.less
 //                                                 ^ punctuation.definition.string.end.less
+//                                                  ^ punctuation.terminator.rule.less
 }
 
 /* CSS Variables */
@@ -309,18 +409,32 @@
 /* Misc Functions */
 .a {
     color: color('#aaa');
+//^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^ support.type.property-name.less
+//       ^ punctuation.separator.key-value.less
+//        ^^^^^^^^^^^^^^ meta.property-value.less
 //         ^^^^^^^^^^^^^ meta.function-call.less
 //         ^^^^^ support.function.color.less
 //              ^ punctuation.definition.group.begin.less
-//               ^^^^^^ string.quoted
+//               ^^^^^^ string.quoted.single.less
+//               ^ punctuation.definition.string.begin.less
+//                    ^ punctuation.definition.string.end.less
 //                     ^ punctuation.definition.group.end.less
+//                      ^ punctuation.terminator.rule.less
 
     background-size: image-size("i.png");
-//                   ^^^^^^^^^^^^^^^^^^^^^ meta.function-call.less
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^^^^^^^^^^^ support.type.property-name.less
+//                 ^ punctuation.separator.key-value.less
+//                  ^^^^^^^^^^^^^^^^^^^^ meta.property-value.less
+//                   ^^^^^^^^^^^^^^^^^^^ meta.function-call.less
 //                   ^^^^^^^^^^ support.function.image.less
 //                             ^ punctuation.definition.group.begin.less
-//                              ^^^^^^^ string.quoted
+//                              ^^^^^^^ string.quoted.double.less
+//                              ^ punctuation.definition.string.begin.less
+//                                    ^ punctuation.definition.string.end.less
 //                                     ^ punctuation.definition.group.end.less
+//                                      ^ punctuation.terminator.rule.less
     width: image-width("i.png");
 //         ^^^^^^^^^^^^^^^^^^^^ meta.function-call.less
 //         ^^^^^^^^^^^ support.function.image.less
@@ -358,6 +472,10 @@ background-image:
 //                                                     ^ punctuation.definition.group.end.less
 
 width: unit(5, px);
+//^^^^^^^^^^^^^^^^^ meta.property-list.less
+//^^^ support.type.property-name.less
+//   ^ punctuation.separator.key-value.less
+//    ^^^^^^^^^^^^ meta.property-value.less
 //     ^^^^^^^^^^^ meta.function-call.less
 //     ^^^^ support.function.convert.less
 //         ^ punctuation.definition.group.begin.less
@@ -365,14 +483,20 @@ width: unit(5, px);
 //           ^ punctuation.separator.less
 //             ^^ keyword.other.unit.less
 //               ^ punctuation.definition.group.end.less
+//                ^ punctuation.terminator.rule.less
 
 width: get-unit(5px);
+//^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//^^^ support.type.property-name.less
+//   ^ punctuation.separator.key-value.less
+//    ^^^^^^^^^^^^^^ meta.property-value.less
 //     ^^^^^^^^^^^^^ meta.function-call.less
-//     ^^^^^^^^ support.function.convert.less
+//     ^^^^^^^^ support.function.get-unit.less
 //             ^ punctuation.definition.group.begin.less
 //              ^^^ constant.numeric.less
 //               ^^ keyword.other.unit.less
 //                 ^ punctuation.definition.group.end.less
+//                  ^ punctuation.terminator.rule.less
 
 background-image: svg-gradient(to right, red, green 30%, blue);
 //                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.less
@@ -438,27 +562,46 @@ filter: e("ms:alwaysHasItsOwnSyntax.For.Stuff()");
 /* Math Functions */
 #math-functions {
     width: calc(100% - (@asdf / 2) / var(--asdf));
-  //       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.less
-  //       ^^^^ support.function.calc.less
-  //           ^ punctuation.definition.group.begin.less
-  //            ^^^^ constant.numeric.less
-  //               ^ keyword.other.unit.less
-  //                 ^ keyword.operator.arithmetic.less
-  //                    ^^^^^ variable.other.readwrite.less
-  //                   ^^^^^^^^^^^ meta.group.less
-  //                   ^ punctuation.definition.group.begin.less
-  //                             ^ punctuation.definition.group.end.less
-  //                              ^ punctuation.definition.group.end.less
-  //                               ^ keyword.operator.arithmetic.less
-  //                                 ^^^^^^^^^^^ meta.function-call.less
-  //                                 ^^^ support.function.var.less
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^ support.type.property-name.less
+//       ^ punctuation.separator.key-value.less
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-value.less
+//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.less
+//         ^^^^ support.function.calc.less
+//             ^ punctuation.definition.group.begin.less
+//              ^^^^ constant.numeric.less
+//                 ^ keyword.other.unit.less
+//                   ^ keyword.operator.arithmetic.less
+//                     ^^^^^^^^^^^ meta.group.less
+//                     ^ punctuation.definition.group.begin.less
+//                      ^^^^^ variable.other.readwrite.less
+//                      ^ punctuation.definition.variable.less
+//                       ^^^^ support.other.variable.less
+//                            ^ keyword.operator.arithmetic.less
+//                              ^ constant.numeric.less
+//                               ^ punctuation.definition.group.end.less
+//                                 ^ keyword.operator.arithmetic.less
+//                                   ^^^^^^^^^^^ meta.function-call.less
+//                                   ^^^ support.function.var.less
+//                                      ^ punctuation.definition.group.begin.less
+//                                       ^^^^^^ support.type.custom-property.less
+//                                       ^^ punctuation.definition.custom-property.less
+//                                         ^^^^ support.type.custom-property.name.less
+//                                             ^ punctuation.definition.group.end.less
+//                                              ^ punctuation.definition.group.end.less
+//                                               ^ punctuation.terminator.rule.less
 
     width: ceil(1.1);
+//^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^ support.type.property-name.less
+//       ^ punctuation.separator.key-value.less
+//        ^^^^^^^^^^ meta.property-value.less
 //         ^^^^^^^^^ meta.function-call.less
 //         ^^^^ support.function.math.less
 //             ^ punctuation.definition.group.begin.less
 //              ^^^ constant.numeric.less
-//                  ^ punctuation.definition.group.end.less
+//                 ^ punctuation.definition.group.end.less
+//                  ^ punctuation.terminator.rule.less
     width: floor(1.1);
 //         ^^^^^^^^^^ meta.function-call.less
 //         ^^^^^ support.function.math.less
@@ -585,39 +728,88 @@ filter: e("ms:alwaysHasItsOwnSyntax.For.Stuff()");
 //                    ^ punctuation.definition.group.end.less
 
     @val: iskeyword(color);
-//        ^^^^^^^^^^^^^^^^^^ meta.function-call.less
+//^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^^^^^^^^^^^^^^^^^^^ meta.property-value.less
+//  ^^^^ variable.other.readwrite.less
+//  ^ punctuation.definition.variable.less
+//   ^^^ support.other.variable.less
+//      ^ punctuation.separator.key-value.less
+//       ^ meta.property-value.less
+//        ^^^^^^^^^^^^^^^^ meta.function-call.less
 //        ^^^^^^^^^ support.function.type.less
 //                 ^ punctuation.definition.group.begin.less
 //                  ^^^^^ support.constant.property-value.less
-//                         ^ punctuation.definition.group.end.less
+//                       ^ punctuation.definition.group.end.less
+//                        ^ punctuation.terminator.rule.less
 
     @val: isurl(url("asdf"));
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-value.less
+//  ^^^^ variable.other.readwrite.less
+//  ^ punctuation.definition.variable.less
+//   ^^^ support.other.variable.less
+//      ^ punctuation.separator.key-value.less
+//       ^ meta.property-value.less
 //        ^^^^^^^^^^^^^^^^^^ meta.function-call.less
 //        ^^^^^ support.function.type.less
 //             ^ punctuation.definition.group.begin.less
 //              ^^^^^^^^^^^ meta.function-call.less
+//              ^^^ support.function.url.less
+//                 ^ punctuation.definition.group.begin.less
+//                  ^^^^^^ string.quoted.double.less
+//                  ^ punctuation.definition.string.begin.less
+//                       ^ punctuation.definition.string.end.less
+//                        ^ punctuation.definition.group.end.less
 //                         ^ punctuation.definition.group.end.less
+//                          ^ punctuation.terminator.rule.less
 
     @val: ispixel(1px);
-//        ^^^^^^^^^^^^^ meta.function-call.less
+//^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^^^^^^^^^^^^^^^ meta.property-value.less
+//  ^^^^ variable.other.readwrite.less
+//  ^ punctuation.definition.variable.less
+//   ^^^ support.other.variable.less
+//      ^ punctuation.separator.key-value.less
+//       ^ meta.property-value.less
+//        ^^^^^^^^^^^^ meta.function-call.less
 //        ^^^^^^^ support.function.type.less
 //               ^ punctuation.definition.group.begin.less
-//                ^^^ variable.other.readwrite.less
+//                ^^^ constant.numeric.less
+//                 ^^ keyword.other.unit.less
 //                   ^ punctuation.definition.group.end.less
+//                    ^ punctuation.terminator.rule.less
 
     @val: isem(1em);
+//^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^^^^^^^^^^^^ meta.property-value.less
+//  ^^^^ variable.other.readwrite.less
+//  ^ punctuation.definition.variable.less
+//   ^^^ support.other.variable.less
+//      ^ punctuation.separator.key-value.less
+//       ^ meta.property-value.less
 //        ^^^^^^^^^ meta.function-call.less
 //        ^^^^ support.function.type.less
 //            ^ punctuation.definition.group.begin.less
 //             ^^^ constant.numeric.less
-//                 ^ punctuation.definition.group.end.less
+//              ^^ keyword.other.unit.less
+//                ^ punctuation.definition.group.end.less
+//                 ^ punctuation.terminator.rule.less
 
     @val: ispercentage(1%);
-//        ^^^^^^^^^^^^^^^^^ meta.function-call.less
+//^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^^^^^^^^^^^^^^^^^^^ meta.property-value.less
+//  ^^^^ variable.other.readwrite.less
+//  ^ punctuation.definition.variable.less
+//   ^^^ support.other.variable.less
+//      ^ punctuation.separator.key-value.less
+//       ^ meta.property-value.less
+//        ^^^^^^^^^^^^^^^^ meta.function-call.less
 //        ^^^^^^^^^^^^ support.function.type.less
 //                    ^ punctuation.definition.group.begin.less
 //                     ^^ constant.numeric.less
+//                      ^ keyword.other.unit.less
 //                       ^ punctuation.definition.group.end.less
+//                        ^ punctuation.terminator.rule.less
 
     @val: isunit(1%, mm);
 //        ^^^^^^^^^^^^^^ meta.function-call.less
@@ -772,79 +964,297 @@ filter: e("ms:alwaysHasItsOwnSyntax.For.Stuff()");
 /* Color Operation Functions */
 #color-operation-functions {
     color: saturate(hsl(90, 80%, 50%), 20%);
-//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.les
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^ support.type.property-name.less
+//       ^ punctuation.separator.key-value.less
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-value.less
+//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.less
 //         ^^^^^^^^ support.function.color-operation.less
 //                 ^ punctuation.definition.group.begin.less
+//                  ^^^^^^^^^^^^^^^^^ meta.function-call.less
+//                  ^^^ support.function.color.less
+//                     ^ punctuation.definition.group.begin.less
+//                      ^^ constant.numeric.less
+//                        ^ punctuation.separator.less
+//                          ^^^ constant.numeric.less
+//                            ^ keyword.other.unit.less
+//                             ^ punctuation.separator.less
+//                               ^^^ constant.numeric.less
+//                                 ^ keyword.other.unit.less
+//                                  ^ punctuation.definition.group.end.less
+//                                   ^ punctuation.separator.less
+//                                     ^^^ constant.numeric.less
+//                                       ^ keyword.other.unit.less
 //                                        ^ punctuation.definition.group.end.less
+//                                         ^ punctuation.terminator.rule.less
     color: desaturate(hsl(90, 80%, 50%), 20%);
-//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.les
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^ support.type.property-name.less
+//       ^ punctuation.separator.key-value.less
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-value.less
+//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.less
 //         ^^^^^^^^^^ support.function.color-operation.less
 //                   ^ punctuation.definition.group.begin.less
-//                                          ^ punctuation.definition.group.end.less
-    color: lighten(hsl(90, 80%, 50%), 20%);
-//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.les
-//         ^^^^^^^ support.function.color-operation.less
-//                ^ punctuation.definition.group.begin.less
-//                                       ^ punctuation.definition.group.end.less
-    color: darken(hsl(90, 80%, 50%), 20%);
-//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.les
-//         ^^^^^^ support.function.color-operation.less
-//               ^ punctuation.definition.group.begin.less
-//                                      ^ punctuation.definition.group.end.less
-    color: fadein(hsl(90, 80%, 50%), 20%);
-//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.les
-//         ^^^^^^ support.function.color-operation.less
-//               ^ punctuation.definition.group.begin.less
-//                                      ^ punctuation.definition.group.end.less
-    color: fadeout(hsl(90, 80%, 50%), 20%, relative);
-//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.les
-//         ^^^^^^^ support.function.color-operation.less
-//                ^ punctuation.definition.group.begin.less
-//                                                 ^ punctuation.definition.group.end.less
-    color: fade(hsl(90, 80%, 50%), 20%);
-//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.les
-//         ^^^^ support.function.color-operation.less
-//             ^ punctuation.definition.group.begin.less
+//                    ^^^^^^^^^^^^^^^^^ meta.function-call.less
+//                    ^^^ support.function.color.less
+//                       ^ punctuation.definition.group.begin.less
+//                        ^^ constant.numeric.less
+//                          ^ punctuation.separator.less
+//                            ^^^ constant.numeric.less
+//                              ^ keyword.other.unit.less
+//                               ^ punctuation.separator.less
+//                                 ^^^ constant.numeric.less
+//                                   ^ keyword.other.unit.less
 //                                    ^ punctuation.definition.group.end.less
-    color: spin(hsl(10, 90%, 50%), 30);
-//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.les
+//                                     ^ punctuation.separator.less
+//                                       ^^^ constant.numeric.less
+//                                         ^ keyword.other.unit.less
+//                                          ^ punctuation.definition.group.end.less
+//                                           ^ punctuation.terminator.rule.less
+    color: lighten(hsl(90, 80%, 50%), 20%);
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^ support.type.property-name.less
+//       ^ punctuation.separator.key-value.less
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-value.less
+//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.less
+//         ^^^^^^^ support.function.color-operation.less
+//                ^ punctuation.definition.group.begin.less
+//                 ^^^^^^^^^^^^^^^^^ meta.function-call.less
+//                 ^^^ support.function.color.less
+//                    ^ punctuation.definition.group.begin.less
+//                     ^^ constant.numeric.less
+//                       ^ punctuation.separator.less
+//                         ^^^ constant.numeric.less
+//                           ^ keyword.other.unit.less
+//                            ^ punctuation.separator.less
+//                              ^^^ constant.numeric.less
+//                                ^ keyword.other.unit.less
+//                                 ^ punctuation.definition.group.end.less
+//                                  ^ punctuation.separator.less
+//                                    ^^^ constant.numeric.less
+//                                      ^ keyword.other.unit.less
+//                                       ^ punctuation.definition.group.end.less
+//                                        ^ punctuation.terminator.rule.less
+    color: darken(hsl(90, 80%, 50%), 20%);
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^ support.type.property-name.less
+//       ^ punctuation.separator.key-value.less
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-value.less
+//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.less
+//         ^^^^^^ support.function.color-operation.less
+//               ^ punctuation.definition.group.begin.less
+//                ^^^^^^^^^^^^^^^^^ meta.function-call.less
+//                ^^^ support.function.color.less
+//                   ^ punctuation.definition.group.begin.less
+//                    ^^ constant.numeric.less
+//                      ^ punctuation.separator.less
+//                        ^^^ constant.numeric.less
+//                          ^ keyword.other.unit.less
+//                           ^ punctuation.separator.less
+//                             ^^^ constant.numeric.less
+//                               ^ keyword.other.unit.less
+//                                ^ punctuation.definition.group.end.less
+//                                 ^ punctuation.separator.less
+//                                   ^^^ constant.numeric.less
+//                                     ^ keyword.other.unit.less
+//                                      ^ punctuation.definition.group.end.less
+//                                       ^ punctuation.terminator.rule.less
+    color: fadein(hsl(90, 80%, 50%), 20%);
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^ support.type.property-name.less
+//       ^ punctuation.separator.key-value.less
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-value.less
+//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.less
+//         ^^^^^^ support.function.color-operation.less
+//               ^ punctuation.definition.group.begin.less
+//                ^^^^^^^^^^^^^^^^^ meta.function-call.less
+//                ^^^ support.function.color.less
+//                   ^ punctuation.definition.group.begin.less
+//                    ^^ constant.numeric.less
+//                      ^ punctuation.separator.less
+//                        ^^^ constant.numeric.less
+//                          ^ keyword.other.unit.less
+//                           ^ punctuation.separator.less
+//                             ^^^ constant.numeric.less
+//                               ^ keyword.other.unit.less
+//                                ^ punctuation.definition.group.end.less
+//                                 ^ punctuation.separator.less
+//                                   ^^^ constant.numeric.less
+//                                     ^ keyword.other.unit.less
+//                                      ^ punctuation.definition.group.end.less
+//                                       ^ punctuation.terminator.rule.less
+    color: fadeout(hsl(90, 80%, 50%), 20%, relative);
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^ support.type.property-name.less
+//       ^ punctuation.separator.key-value.less
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-value.less
+//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.less
+//         ^^^^^^^ support.function.color-operation.less
+//                ^ punctuation.definition.group.begin.less
+//                 ^^^^^^^^^^^^^^^^^ meta.function-call.less
+//                 ^^^ support.function.color.less
+//                    ^ punctuation.definition.group.begin.less
+//                     ^^ constant.numeric.less
+//                       ^ punctuation.separator.less
+//                         ^^^ constant.numeric.less
+//                           ^ keyword.other.unit.less
+//                            ^ punctuation.separator.less
+//                              ^^^ constant.numeric.less
+//                                ^ keyword.other.unit.less
+//                                 ^ punctuation.definition.group.end.less
+//                                  ^ punctuation.separator.less
+//                                    ^^^ constant.numeric.less
+//                                      ^ keyword.other.unit.less
+//                                       ^ punctuation.separator.less
+//                                         ^^^^^^^^ constant.language.relative.less
+//                                                 ^ punctuation.definition.group.end.less
+//                                                  ^ punctuation.terminator.rule.less
+    color: fade(hsl(90, 80%, 50%), 20%);
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^ support.type.property-name.less
+//       ^ punctuation.separator.key-value.less
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-value.less
+//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.less
 //         ^^^^ support.function.color-operation.less
 //             ^ punctuation.definition.group.begin.less
+//              ^^^^^^^^^^^^^^^^^ meta.function-call.less
+//              ^^^ support.function.color.less
+//                 ^ punctuation.definition.group.begin.less
+//                  ^^ constant.numeric.less
+//                    ^ punctuation.separator.less
+//                      ^^^ constant.numeric.less
+//                        ^ keyword.other.unit.less
+//                         ^ punctuation.separator.less
+//                           ^^^ constant.numeric.less
+//                             ^ keyword.other.unit.less
+//                              ^ punctuation.definition.group.end.less
+//                               ^ punctuation.separator.less
+//                                 ^^^ constant.numeric.less
+//                                   ^ keyword.other.unit.less
+//                                    ^ punctuation.definition.group.end.less
+//                                     ^ punctuation.terminator.rule.less
+    color: spin(hsl(10, 90%, 50%), 30);
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^ support.type.property-name.less
+//       ^ punctuation.separator.key-value.less
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-value.less
+//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.less
+//         ^^^^ support.function.color-operation.less
+//             ^ punctuation.definition.group.begin.less
+//              ^^^^^^^^^^^^^^^^^ meta.function-call.less
+//              ^^^ support.function.color.less
+//                 ^ punctuation.definition.group.begin.less
+//                  ^^ constant.numeric.less
+//                    ^ punctuation.separator.less
+//                      ^^^ constant.numeric.less
+//                        ^ keyword.other.unit.less
+//                         ^ punctuation.separator.less
+//                           ^^^ constant.numeric.less
+//                             ^ keyword.other.unit.less
+//                              ^ punctuation.definition.group.end.less
+//                               ^ punctuation.separator.less
+//                                 ^^ constant.numeric.less
 //                                   ^ punctuation.definition.group.end.less
+//                                    ^ punctuation.terminator.rule.less
     color: mix(#ff0000, #0000ff, 50%);
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^ support.type.property-name.less
+//       ^ punctuation.separator.key-value.less
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-value.less
 //         ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.less
 //         ^^^ support.function.color-operation.less
 //            ^ punctuation.definition.group.begin.less
 //             ^^^^^^^ constant.other.color.rgb-value.less
+//             ^ punctuation.definition.constant.less
 //                    ^ punctuation.separator.less
+//                      ^^^^^^^ constant.other.color.rgb-value.less
+//                      ^ punctuation.definition.constant.less
+//                             ^ punctuation.separator.less
 //                               ^^^ constant.numeric.less
+//                                 ^ keyword.other.unit.less
 //                                  ^ punctuation.definition.group.end.less
+//                                   ^ punctuation.terminator.rule.less
     color: tint(#007fff, 50%);
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^ support.type.property-name.less
+//       ^ punctuation.separator.key-value.less
+//        ^^^^^^^^^^^^^^^^^^^ meta.property-value.less
 //         ^^^^^^^^^^^^^^^^^^ meta.function-call.less
 //         ^^^^ support.function.color-operation.less
 //             ^ punctuation.definition.group.begin.less
 //              ^^^^^^^ constant.other.color.rgb-value.less
+//              ^ punctuation.definition.constant.less
+//                     ^ punctuation.separator.less
+//                       ^^^ constant.numeric.less
+//                         ^ keyword.other.unit.less
 //                          ^ punctuation.definition.group.end.less
+//                           ^ punctuation.terminator.rule.less
     color: shade(#007fff, 50%);
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^ support.type.property-name.less
+//       ^ punctuation.separator.key-value.less
+//        ^^^^^^^^^^^^^^^^^^^^ meta.property-value.less
 //         ^^^^^^^^^^^^^^^^^^^ meta.function-call.less
 //         ^^^^^ support.function.color-operation.less
 //              ^ punctuation.definition.group.begin.less
 //               ^^^^^^^ constant.other.color.rgb-value.less
+//               ^ punctuation.definition.constant.less
+//                      ^ punctuation.separator.less
+//                        ^^^ constant.numeric.less
+//                          ^ keyword.other.unit.less
 //                           ^ punctuation.definition.group.end.less
+//                            ^ punctuation.terminator.rule.less
     color: greyscale(hsl(90, 90%, 50%));
-//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.les
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^ support.type.property-name.less
+//       ^ punctuation.separator.key-value.less
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-value.less
+//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.less
 //         ^^^^^^^^^ support.function.color-operation.less
 //                  ^ punctuation.definition.group.begin.less
+//                   ^^^^^^^^^^^^^^^^^ meta.function-call.less
+//                   ^^^ support.function.color.less
+//                      ^ punctuation.definition.group.begin.less
+//                       ^^ constant.numeric.less
+//                         ^ punctuation.separator.less
+//                           ^^^ constant.numeric.less
+//                             ^ keyword.other.unit.less
+//                              ^ punctuation.separator.less
+//                                ^^^ constant.numeric.less
+//                                  ^ keyword.other.unit.less
+//                                   ^ punctuation.definition.group.end.less
 //                                    ^ punctuation.definition.group.end.less
+//                                     ^ punctuation.terminator.rule.less
     color: contrast(hsl(90, 100%, 50%), #000000, #ffffff, 80%);
-//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.les
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^ support.type.property-name.less
+//       ^ punctuation.separator.key-value.less
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-value.less
+//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.less
 //         ^^^^^^^^ support.function.color-operation.less
 //                 ^ punctuation.definition.group.begin.less
 //                  ^^^^^^^^^^^^^^^^^^ meta.function-call.less
+//                  ^^^ support.function.color.less
+//                     ^ punctuation.definition.group.begin.less
+//                      ^^ constant.numeric.less
+//                        ^ punctuation.separator.less
+//                          ^^^^ constant.numeric.less
+//                             ^ keyword.other.unit.less
+//                              ^ punctuation.separator.less
+//                                ^^^ constant.numeric.less
+//                                  ^ keyword.other.unit.less
+//                                   ^ punctuation.definition.group.end.less
 //                                    ^ punctuation.separator.less
 //                                      ^^^^^^^ constant.other.color.rgb-value.less
+//                                      ^ punctuation.definition.constant.less
+//                                             ^ punctuation.separator.less
+//                                               ^^^^^^^ constant.other.color.rgb-value.less
+//                                               ^ punctuation.definition.constant.less
+//                                                      ^ punctuation.separator.less
 //                                                        ^^^ constant.numeric.less
+//                                                          ^ keyword.other.unit.less
 //                                                           ^ punctuation.definition.group.end.less
+//                                                            ^ punctuation.terminator.rule.less
 }
 
 /* Color Blending Functions */
@@ -923,9 +1333,13 @@ filter: e("ms:alwaysHasItsOwnSyntax.For.Stuff()");
 }
 
 input::-webkit-slider-runnable-track { }
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.selector.less
+//^^^ entity.name.tag.less
 //   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ entity.other.attribute-name.pseudo-element.less
 //   ^^ punctuation.definition.entity.less
-//     ^^^^^^^^ support.type.vendor-prefix.less
+//     ^^^^^^^^ meta.namespace.vendor-prefix.less
+//                                   ^ meta.property-list.less punctuation.definition.block.begin.less
+//                                     ^ punctuation.definition.block.end.less
 
 a {
 	animation: anim 1s ease-in-out;
@@ -973,14 +1387,26 @@ a {
 .orderOfEvaluation(@a1, @a2, @a3) when ((@a1) and (@a2) or (@a3)) {}
 div {
     margin: if((2 > 1), 0, 3px);
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.less
+//  ^^^^^^ support.type.property-name.less
+//        ^ punctuation.separator.key-value.less
+//         ^^^^^^^^^^^^^^^^^^^^ meta.property-value.less
 //          ^^^^^^^^^^^^^^^^^^^ meta.function-call.less
 //          ^^ support.function.if.less
 //            ^ punctuation.definition.group.begin.less
-//             ^^^^^^^ meta.group.less
+//             ^^^^^^ meta.group.less
 //             ^ punctuation.definition.group.begin.less
+//              ^ constant.numeric.less
 //                ^ keyword.operator.logical.less
+//                  ^ constant.numeric.less
 //                   ^ punctuation.definition.group.end.less
 //                    ^ punctuation.separator.less
+//                      ^ constant.numeric.less
+//                       ^ punctuation.separator.less
+//                         ^^^ constant.numeric.less
+//                          ^^ keyword.other.unit.less
+//                            ^ punctuation.definition.group.end.less
+//                             ^ punctuation.terminator.rule.less
 
     color:  if((iscolor(@some)), @some, black);
 }


### PR DESCRIPTION
* Fixes units on `0` values (ex. `0px`)
* Fixes interpolated property names
* Fixes semicolons after mixins

Closes #51.